### PR TITLE
Updated bgb32 up to 1.6.4

### DIFF
--- a/evilemu/bgb.py
+++ b/evilemu/bgb.py
@@ -1,3 +1,4 @@
+import re
 from evilemu.emulator import Emulator
 from evilemu.process import Process
 from typing import Generator
@@ -8,11 +9,33 @@ class BGB32(Emulator):
     def find_all() -> Generator[Emulator, None, None]:
         for process in Process.find_processes("bgb.exe"):
             try:
+                version = 'unknown'
+
+                # One byte between the chunks varies with version
+                # Last chunk ends with 'bgb1.' to pinpoint the right spot, which is fragile but at least detects 1.5.x correctly
+                version_address = next(process.search_chunks(
+                    (0, b'\xFF\xFF\xFF\xFF'),
+                    (5, b'\x00\x00\x00\x62\x67\x62\x31\x2E'),
+                ), False)
+
+                if version_address:
+                    # Should give us something like 'bgb1.5.11___'
+                    # We read some junk at the end for extra digits in the future
+                    version_address += 8
+                    version = process.read_memory(version_address, 12).decode('utf-8', errors='ignore')
+
+                hram_offset = 0x130
+
+                version_chunks = [int(x) for x in re.findall('(\d+)', version)]
+                if version_chunks[1] >= 6 and version_chunks[2] >= 1:
+                    # Tested with 1.6.1-4
+                    hram_offset = 0x248
+
                 for base_address in process.search(b'\x6D\x61\x69\x6E\x6C\x6F\x6F\x70\x83\xC4\xF4\xA1'):
                     main_address = process.read_pointer_chain32(base_address + 12, 0, 0, 0x34)
                     rom_address = process.read_pointer32(main_address + 0x10)
                     ram_address = process.read_pointer32(main_address + 0x108)
-                    hram_address = process.read_pointer32(main_address + 0x130)
+                    hram_address = process.read_pointer32(main_address + hram_offset)
                     if rom_address != 0 and ram_address != 0:
                         yield BGB32(process, rom_address, ram_address, hram_address)
             except IOError:


### PR DESCRIPTION
Looks like 32 bit BGB just changed the HRAM offset back in 1.6.1. This worked for me on 1.6.1 through 1.6.4.

64 bit has changed more significantly, as far as I can tell. I'm ready to throw in the towel on manually poking around in a hex editor - I think I'd have to write a tool to make progress, which I'm... not looking forward to.